### PR TITLE
Make low_cpu_mem_usage a configurable parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ accelerate launch \
     --dataloader_num_workers 1 \
     --per_device_train_batch_size "$BSZ" --per_device_eval_batch_size "$BSZ" \
     --fp16 true \
+    --low_cpu_mem_usage true \
     --evaluation_strategy "steps" --eval_steps 128 \
     --save_strategy "steps" --save_steps 128 \
     --save_total_limit 2 \

--- a/training/hf_trainer.py
+++ b/training/hf_trainer.py
@@ -11,6 +11,9 @@ from profiling import ProfilerCallback, build_profiler_configuration
 
 @dataclass
 class ModelArguments:
+    low_cpu_mem_usage: bool = field(
+        metadata={"help": "Try to reduce CPU memory usage while loading the model."},
+        default=True)
     model_name_or_path: t.Optional[str] = field(
         default="EleutherAI/pythia-70m-deduped")
     use_xformers: bool = field(default=False, metadata={"help": "Use xFormers' memory_efficient_attention"})
@@ -93,7 +96,7 @@ def main() -> None:
 
     model = transformers.AutoModelForCausalLM.from_pretrained(
         model_args.model_name_or_path,
-        low_cpu_mem_usage=True,
+        low_cpu_mem_usage=model_args.low_cpu_mem_usage,
         torch_dtype=model_load_dtype,
     ).cuda()
 


### PR DESCRIPTION
DeepSpeed Zero-3 does not support loading models with low_cpu_mem_usage=True so I made it a customizable parameter.